### PR TITLE
Fixed. can not call GitLab API using gitlab v4+

### DIFF
--- a/gitlab_mr_release.gemspec
+++ b/gitlab_mr_release.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "dotenv"
-  spec.add_dependency "gitlab"
+  spec.add_dependency "gitlab", ">= 4.0.0"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "activesupport"

--- a/lib/gitlab_mr_release/project.rb
+++ b/lib/gitlab_mr_release/project.rb
@@ -14,7 +14,7 @@ module GitlabMrRelease
     end
 
     def web_url
-      @web_url ||= Gitlab.project(escaped_project_name).web_url
+      @web_url ||= Gitlab.project(@project_name).web_url
     end
 
     # find merge requests between from...to
@@ -22,7 +22,7 @@ module GitlabMrRelease
     # @param to   [String]
     # @return [Array<Integer>] MergeRequest iids
     def merge_request_iids_between(from, to)
-      commits = Gitlab.repo_compare(escaped_project_name, from, to).commits
+      commits = Gitlab.repo_compare(@project_name, from, to).commits
       commits.map do |commit|
         commit["message"] =~ /^Merge branch .*See merge request \!(\d+)$/m
         $1
@@ -31,7 +31,7 @@ module GitlabMrRelease
 
     # find MergeRequest with iid
     def merge_request(iid)
-      mr = Gitlab.merge_requests(escaped_project_name, iid: iid).first
+      mr = Gitlab.merge_requests(@project_name, iid: iid).first
       assert_merge_request_iid(mr, iid) if mr
       mr
     end
@@ -49,14 +49,10 @@ module GitlabMrRelease
         description:   generate_description(iids, template),
         labels:        labels,
       }
-      Gitlab.create_merge_request(escaped_project_name, title, options)
+      Gitlab.create_merge_request(@project_name, title, options)
     end
 
     private
-
-    def escaped_project_name
-      CGI.escape(@project_name)
-    end
 
     def assert_merge_request_iid(mr, iid)
       # NOTE: MR is found, but server is old GitLab?

--- a/spec/gitlab_mr_release/project_spec.rb
+++ b/spec/gitlab_mr_release/project_spec.rb
@@ -12,7 +12,7 @@ describe GitlabMrRelease::Project do
   let(:api_endpoint)         { "http://example.com/api/v3" }
   let(:private_token)        { "XXXXXXXXXXXXXXXXXXX" }
   let(:project_name)         { "group/name" }
-  let(:escaped_project_name) { "group%252Fname" }
+  let(:escaped_project_name) { "group%2Fname" }
   let(:web_url)              { "http://example.com/#{project_name}" }
 
   before do


### PR DESCRIPTION
arg is always encoded since v4.0.0
ttps://github.com/NARKOZ/gitlab/pull/253

So, I removed unnecessary encoding