### PR TITLE
Updating the release MR

### DIFF
--- a/spec/gitlab_mr_release/project_spec.rb
+++ b/spec/gitlab_mr_release/project_spec.rb
@@ -98,4 +98,22 @@ describe GitlabMrRelease::Project do
 
     it { should eq description }
   end
+
+  describe "#find_current_release_mr" do
+    before do
+      stub_request(:get, "#{api_endpoint}/projects/#{escaped_project_name}/merge_requests?state=opened").
+        with(headers: { "Accept" => "application/json", "Private-Token" => private_token }).
+        to_return(status: 200, body: read_stub("merge_requests_with_state_opened.json"), headers: {})
+    end
+
+    context("the release mr exists") do
+      subject { project.find_current_release_mr("develop", "master") }
+      it { should_not be_nil }
+    end
+
+    context("the release mr does not exist") do
+      subject { project.find_current_release_mr("develop", "release") }
+      it { should be_nil }
+    end
+  end
 end

--- a/spec/gitlab_mr_release/project_spec.rb
+++ b/spec/gitlab_mr_release/project_spec.rb
@@ -108,7 +108,12 @@ describe GitlabMrRelease::Project do
 
     context("the release mr exists") do
       subject { project.find_current_release_mr("develop", "master") }
-      it { should_not be_nil }
+      it "returns an instance of mr" do
+        mr = subject
+
+        expect(mr).to be_an_instance_of Gitlab::ObjectifiedHash
+        expect(mr.id).to eq 165679
+      end
     end
 
     context("the release mr does not exist") do

--- a/spec/support/stub/merge_requests_with_state_opened.json
+++ b/spec/support/stub/merge_requests_with_state_opened.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 165679,
+    "iid": 5,
+    "project_id": 499527,
+    "title": "Add yes",
+    "description": "",
+    "state": "merged",
+    "created_at": "2015-09-30T16:26:45.134Z",
+    "updated_at": "2015-09-30T16:27:00.900Z",
+    "target_branch": "master",
+    "source_branch": "develop",
+    "upvotes": 0,
+    "downvotes": 0,
+    "author": {
+      "name": "sue445",
+      "username": "sue445",
+      "id": 125864,
+      "state": "active",
+      "avatar_url": "https://secure.gravatar.com/avatar/fbf625a9c371d2d87fe0d4343b68dc65?s=40&d=identicon",
+      "web_url": "https://gitlab.com/u/sue445"
+    },
+    "assignee": null,
+    "source_project_id": 499527,
+    "target_project_id": 499527,
+    "labels": [],
+    "work_in_progress": null,
+    "milestone": null
+  }
+]


### PR DESCRIPTION
Updating the release MR if it already exists when `gitlab_mr_release create` is executed. 

This is the same as git-pr-release behavior.

limitations of this pull request
 -  All checkboxes are unchecked when the MR is updated.