### PR TITLE
preserve checkbox statuses on update.

### DIFF
--- a/spec/gitlab_mr_release/project_spec.rb
+++ b/spec/gitlab_mr_release/project_spec.rb
@@ -121,4 +121,39 @@ describe GitlabMrRelease::Project do
       it { should be_nil }
     end
   end
+
+  describe "#apply_checkbox_statuses" do
+    let(:new_description) do
+      <<-MARKDNWN.strip_heredoc.strip
+      # MergeRequests
+      * [ ] !11 aaa
+      * [ ] !12 bbb
+      * [ ] !13 ccc
+      * [ ] !14 ddd
+      MARKDNWN
+    end
+
+    let(:old_description) do
+      <<-MARKDNWN.strip_heredoc.strip
+      # MergeRequests
+      * [ ] !11 aaa
+      * [x] !12 bbb
+      * [x] !13 ccc
+      MARKDNWN
+    end
+
+    let(:applied_descriptopn) do
+      <<-MARKDNWN.strip_heredoc.strip
+      # MergeRequests
+      * [ ] !11 aaa
+      * [x] !12 bbb
+      * [x] !13 ccc
+      * [ ] !14 ddd
+      MARKDNWN
+    end
+
+    subject { project.apply_checkbox_statuses(new_description, old_description) }
+
+    it { should eq applied_descriptopn }
+  end
 end


### PR DESCRIPTION
In #41, all checkboxes in MR description are unchecked when updating the MR.

This PR add feature to preserve the checkbox statuses when the MR is updated.
