### PR TITLE
Fix deprecation warning at `ERB.new` and requires Ruby 2.6+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,13 @@ on:
 
 jobs:
   test:
-    # runs-on: ubuntu-latest
-    runs-on: ${{ (matrix.runner != '' && matrix.runner) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
 
       matrix:
         ruby:
-          - "2.2"
-          - "2.3"
-          - "2.4"
-          - "2.5"
           - "2.6"
           - "2.7"
           - "3.0"
@@ -33,11 +28,6 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
-
-        include:
-          # ref. https://github.com/ruby/setup-ruby/issues/496#issuecomment-1520662740
-          - ruby: "2.2"
-            runner: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v4

--- a/gitlab_mr_release.gemspec
+++ b/gitlab_mr_release.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/sue445/gitlab_mr_release"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = ">= 2.6.0"
+
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"

--- a/lib/gitlab_mr_release/project.rb
+++ b/lib/gitlab_mr_release/project.rb
@@ -37,7 +37,7 @@ module GitlabMrRelease
 
     def generate_description(iids, template)
       merge_requests = Gitlab.merge_requests(@project_name, iids: iids)
-      ERB.new(template, nil, "-").result(binding).strip
+      ERB.new(template, trim_mode: "-").result(binding).strip
     end
 
     def create_merge_request(source_branch:, target_branch:, title:, template:, labels:)


### PR DESCRIPTION
```
/home/runner/work/gitlab_mr_release/gitlab_mr_release/lib/gitlab_mr_release/project.rb:40: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/home/runner/work/gitlab_mr_release/gitlab_mr_release/lib/gitlab_mr_release/project.rb:40: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

`ERB.new` with keyword arguments is available since Ruby 2.6+. So I dropped Ruby < 2.6

Close #83