### PR TITLE
Add ostruct to development dependency

### DIFF
--- a/gitlab_mr_release.gemspec
+++ b/gitlab_mr_release.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activesupport"
   spec.add_development_dependency "bundler", ">= 1.10"
   spec.add_development_dependency "coveralls_reborn"
+  spec.add_development_dependency "ostruct"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-parameterized"


### PR DESCRIPTION
```
/Users/sue445/workspace/github.com/sue445/gitlab_mr_release/spec/spec_helper.rb:21: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```